### PR TITLE
Create entity fix

### DIFF
--- a/src/featureSelectors.test.ts
+++ b/src/featureSelectors.test.ts
@@ -25,17 +25,89 @@ describe("featureSelectors", () => {
           status: "foo",
         },
       };
+
+      const featureHasStatus = true;
+      const featureHasData = true;
+
       const getDenormalizedData = makeGetDenormalizedData({
         name: "users",
         entity: "users",
       });
-      const output = getDenormalizedData.resultFunc(featureSlices, true);
+
+      const output = getDenormalizedData.resultFunc(
+        featureSlices,
+        featureHasStatus,
+        featureHasData
+      );
+
       expect(output).toEqual({
         users: [
           { id: 1, name: "Garrett" },
           { id: 2, name: "Laura" },
         ],
       });
+    });
+
+    it("should return falsy value when the status of the slice is not yet defined", () => {
+      const featureSlices = {
+        entities: {
+          users: { 1: { id: 1, name: "Garrett" }, 2: { id: 2, name: "Laura" } },
+          animals: { 1: { id: 1, name: "dog" }, 2: { id: 2, name: "cat" } },
+        },
+        users: {
+          data: { users: [1, 2] },
+          status: "test",
+        },
+        animals: {
+          data: { animals: [1, 2] },
+          status: "foo",
+        },
+      };
+      const getDenormalizedData = makeGetDenormalizedData({
+        name: "users",
+        entity: "users",
+      });
+
+      const featureHasStatus = false;
+      const featureHasData = true;
+
+      const output = getDenormalizedData.resultFunc(
+        featureSlices,
+        featureHasStatus,
+        featureHasData
+      );
+      expect(output).toBeFalsy();
+    });
+
+    it("should return falsy value when the data of the slice is not yet defined", () => {
+      const featureSlices = {
+        entities: {
+          users: { 1: { id: 1, name: "Garrett" }, 2: { id: 2, name: "Laura" } },
+          animals: { 1: { id: 1, name: "dog" }, 2: { id: 2, name: "cat" } },
+        },
+        users: {
+          data: { users: [1, 2] },
+          status: "test",
+        },
+        animals: {
+          data: { animals: [1, 2] },
+          status: "foo",
+        },
+      };
+      const getDenormalizedData = makeGetDenormalizedData({
+        name: "users",
+        entity: "users",
+      });
+
+      const featureHasStatus = true;
+      const featureHasData = false;
+
+      const output = getDenormalizedData.resultFunc(
+        featureSlices,
+        featureHasStatus,
+        featureHasData
+      );
+      expect(output).toBeFalsy();
     });
   });
 });

--- a/src/featureSelectors.ts
+++ b/src/featureSelectors.ts
@@ -25,6 +25,13 @@ export const makeGetFeatureStatus = ({ name }: { name: string }) => {
   );
 };
 
+export const makeGetFeatureData = ({ name }: { name: string }) => {
+  return createSelector(
+    getFeatureSlices,
+    (slices: FeatureSlices<FeatureSlice>) => slices[name]?.data
+  );
+};
+
 export const makeGetIsFeatureFetching = ({ name }: { name: string }) => {
   const getFeatureStatus = makeGetFeatureStatus({ name });
   return createSelector(
@@ -84,13 +91,16 @@ export const makeGetDenormalizedData = ({
   name: string;
   entity: string;
 }) => {
-  const getHasFeatureFetchedSuccess = makeGetHasFeatureFetchedSuccess({ name });
+  const getFeatureStatus = makeGetFeatureStatus({ name });
+  const getFeatureData = makeGetFeatureData({ name });
+
   return createSelector(
     getFeatureSlices,
-    getHasFeatureFetchedSuccess,
-    (slices: FeatureSlices<FeatureSlice>, hasFetchedSuccessfully: boolean) => {
-      if (!hasFetchedSuccessfully || !slices.entities) {
-        return {};
+    getFeatureStatus,
+    getFeatureData,
+    (slices: FeatureSlices<FeatureSlice>, status: string, featureData) => {
+      if (!status || !featureData || !slices.entities) {
+        return undefined;
       }
 
       const { data } = slices[name];


### PR DESCRIPTION
Fix for bug that would cause makeGetDenormalizedData return an empty object even if the entity exists and the feature slice status is in a successful state. 

Add makeGetIsSliceSuccessful that checks if the feature slice state is in one of two successful states HAS_FETCHED_SUCCESS or HAS_CREATED_SUCCESS

use makeGetIsSliceSuccessful in makeGetDenormalizedData to prevent it from returning an empty object if the feature slice status is in HAS_CREATED_SUCCESS. 

Add test to check makeGetDenormalizedData returns empty object if feature slice status is in not in a successful state. 