### PR TITLE
fix(featureslice.ts): fix error type to match expected type in catch

### DIFF
--- a/src/featureSlice.ts
+++ b/src/featureSlice.ts
@@ -47,7 +47,7 @@ export interface FeatureSuccessPayload extends FeaturePayload {
 }
 
 export interface FeatureErrorPayload extends FeaturePayload {
-  error: Error;
+  error: unknown;
 }
 
 export interface FeatureSlice {


### PR DESCRIPTION
The value being passed to onErrorAction was specifically of type Error. However, this is the value
being passed in the catch block, which, by typescript definition, has to be unknown.