### PR TITLE
fix(featuresagas.ts): make error stored predictable

### DIFF
--- a/src/featureSagas.ts
+++ b/src/featureSagas.ts
@@ -67,7 +67,13 @@ export function* genericSagaHandler({
       yield put(onUpdateMetaData({ name, metaData }));
     }
   } catch (error) {
-    yield put(onErrorAction({ name, error }));
+    if (error instanceof Error) {
+      yield put(onErrorAction({ name, error }));
+    } else if (typeof error === "string") {
+      yield put(onErrorAction({ name, error: new Error(error) }));
+    } else {
+      yield put(onErrorAction({ name, error: new Error('Unexpected error attempting to normalize data') }));
+    }
   }
 }
 

--- a/src/featureSlice.ts
+++ b/src/featureSlice.ts
@@ -47,7 +47,7 @@ export interface FeatureSuccessPayload extends FeaturePayload {
 }
 
 export interface FeatureErrorPayload extends FeaturePayload {
-  error: unknown;
+  error: Error;
 }
 
 export interface FeatureSlice {


### PR DESCRIPTION
Make catch case predictable such that the error type returned is of either type Error or string